### PR TITLE
Update install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This build includes:
 
 From a Terminal (⌘-Space, type "Terminal"), simply:
 
-1. Clone this repository: `git clone https://github.com/carlosonunez/obs-installer-for-apple-silicon`, then
+1. Clone this repository: `https://github.com/Zfauser/obs-installer-for-apple-silicon`, then
 2. Install: `cd obs-installer-for-apple-silicon && ./install.sh`
 
 If you want to build a specific version of OBS (that's greater than version 27.0.1),

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ INTERMEDIATE_OBS_DMG_PATH="$OBS_INSTALL_DIR/obs-intermediate.dmg"
 FINAL_OBS_DMG_PATH="$HOME/Downloads/obs-$OBS_VERSION-for-m1.dmg"
 SPEEX_DIR=/tmp/speexdsp
 SPEEX_URI=https://github.com/xiph/speexdsp.git
-
+#TEST
 usage() {
   cat <<-USAGE
 [ENV_VARS] $(basename $0) [OPTIONS]

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ INTERMEDIATE_OBS_DMG_PATH="$OBS_INSTALL_DIR/obs-intermediate.dmg"
 FINAL_OBS_DMG_PATH="$HOME/Downloads/obs-$OBS_VERSION-for-m1.dmg"
 SPEEX_DIR=/tmp/speexdsp
 SPEEX_URI=https://github.com/xiph/speexdsp.git
-
+#test for git vscode
 usage() {
   cat <<-USAGE
 [ENV_VARS] $(basename $0) [OPTIONS]

--- a/install.sh
+++ b/install.sh
@@ -189,7 +189,7 @@ $MIN_SUPPORTED_OBS_MAJOR_VERSION or greater are supported by this script."
 install_dependencies_or_fail() {
   log_info "Installing build dependencies"
   if ! HOMEBREW_NO_AUTO_UPDATE=1 brew install akeru-inc/tap/xcnotary cmake \
-    cmocka ffmpeg jack mbedtls qt@5 swig vlc
+    cmocka ffmpeg jack mbedtls@2 qt@5 swig vlc
   then
     fail "Unable to install one or more OBS dependencies. See log above for more details."
   fi

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ INTERMEDIATE_OBS_DMG_PATH="$OBS_INSTALL_DIR/obs-intermediate.dmg"
 FINAL_OBS_DMG_PATH="$HOME/Downloads/obs-$OBS_VERSION-for-m1.dmg"
 SPEEX_DIR=/tmp/speexdsp
 SPEEX_URI=https://github.com/xiph/speexdsp.git
-#test for git vscode
+
 usage() {
   cat <<-USAGE
 [ENV_VARS] $(basename $0) [OPTIONS]

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ INTERMEDIATE_OBS_DMG_PATH="$OBS_INSTALL_DIR/obs-intermediate.dmg"
 FINAL_OBS_DMG_PATH="$HOME/Downloads/obs-$OBS_VERSION-for-m1.dmg"
 SPEEX_DIR=/tmp/speexdsp
 SPEEX_URI=https://github.com/xiph/speexdsp.git
-#TEST
+
 usage() {
   cat <<-USAGE
 [ENV_VARS] $(basename $0) [OPTIONS]


### PR DESCRIPTION
Changed mbedtls to mbedtls@2 to prevent fatal error: 'mbedtls/arc4.h' file not found. Credit to  
cicloid (https://github.com/carlosonunez/obs-installer-for-apple-silicon/issues/11#issuecomment-882914025) for identifying and resoving the issue.