### PR TITLE
Add requirement of Homebrew and jq to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ This build includes:
 
 From a Terminal (⌘-Space, type "Terminal"), simply:
 
-1. Clone this repository: `git clone https://github.com/carlosonunez/obs-installer-for-apple-silicon`, then
-2. Install: `cd obs-installer-for-apple-silicon && ./install.sh`
+1. Clone this repository: `git clone https://github.com/carlosonunez/obs-installer-for-apple-silicon`
+2. Install jq from [Homebrew](https://brew.sh), via `brew install jq`
+3. Install: `cd obs-installer-for-apple-silicon && ./install.sh`
 
 If you want to build a specific version of OBS (that's greater than version 27.0.1),
 run this:


### PR DESCRIPTION
This goes into the 'How to Use' section. It's unclear otherwise and the script did not prompt to install jq when it was missing.